### PR TITLE
Remove extra space below the end of the page

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,10 +1,8 @@
 function snapper() {
   const form = document.createElement("form");
   const input = document.createElement("input");
-  form.style.visibility = "hidden";
   input.type = "password";
   form.appendChild(input);
-  document.body.appendChild(form);
 }
 
 snapper();


### PR DESCRIPTION
This PR removes the extra space that appears below the end of the page with this extension installed.

In Firefox, all that is necessary for the HTTP padlock to be visible is for a DOM operation with an [`<input type="password">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password) element to happen, it doesn’t actually need to be added to the [`<body>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body) element.

Another way to achieve this would be to change `form.style.visibility = "hidden";` to `form.style.display = "none" !important;`.